### PR TITLE
Add the --datadir option to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,6 +773,12 @@ tool.  It delegates most of the work to a systemd user service.  This
 service is launched by socket activation and only runs when needed.
 If it has no work to do it quits.
 
+setup takes one optional parameter, -d or --datadir.  By default, ccloudvm will store all of the
+files it downloads and all of the instance data that it creates under $HOME/.ccloudvm.  This
+directory can get quite large if you have multiple instances as it will contain the rootfs files
+for those instances.  By specifying the --datadir you can opt to have your instance data stored
+elsewhere.
+
 ### teardown
 
 The ccloudvm teardown command serves two purposes:

--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -156,10 +156,16 @@ func prepareEnv(ctx context.Context, name string) (*workspace, error) {
 		return nil, fmt.Errorf("USER is not defined")
 	}
 
+	dataDir := os.Getenv("CCLOUDVM_DATA_DIR")
+
 	ws.UID = os.Getuid()
 	ws.GID = os.Getgid()
 
-	ws.ccvmDir = path.Join(ws.Home, ".ccloudvm")
+	if dataDir != "" {
+		ws.ccvmDir = path.Join(dataDir, ".ccloudvm")
+	} else {
+		ws.ccvmDir = path.Join(ws.Home, ".ccloudvm")
+	}
 	ws.instanceDir = path.Join(ws.ccvmDir, "instances", name)
 	ws.keyPath = path.Join(ws.ccvmDir, "id_rsa")
 	ws.publicKeyPath = fmt.Sprintf("%s.pub", ws.keyPath)

--- a/ccvm/server.go
+++ b/ccvm/server.go
@@ -600,9 +600,12 @@ DONE:
 }
 
 func makeDir() (string, error) {
-	home := os.Getenv("HOME")
+	home := os.Getenv("CCLOUDVM_DATA_DIR")
 	if home == "" {
-		return "", errors.New("HOME is not defined")
+		home = os.Getenv("HOME")
+		if home == "" {
+			return "", errors.New("HOME is not defined")
+		}
 	}
 	ccvmDir := filepath.Join(home, ".ccloudvm")
 	err := os.MkdirAll(ccvmDir, 0700)

--- a/client/client.go
+++ b/client/client.go
@@ -92,7 +92,7 @@ func getGoPath() (string, error) {
 }
 
 // Setup Installs dependencies
-func Setup(ctx context.Context) error {
+func Setup(ctx context.Context, dataDir string) error {
 	home := os.Getenv("HOME")
 	if home == "" {
 		return errors.New("HOME is not defined")
@@ -115,6 +115,9 @@ func Setup(ctx context.Context) error {
 
 	servicePath := filepath.Join(systemdRootPath, "ccloudvm.service")
 	serviceData := fmt.Sprintf(systemdService, goPath)
+	if dataDir != "" {
+		serviceData += fmt.Sprintf("Environment=\"CCLOUDVM_DATA_DIR=%s\"\n", dataDir)
+	}
 	err = ioutil.WriteFile(servicePath, []byte(serviceData), 0600)
 	if err != nil {
 		return errors.Wrap(err, "Unable to write service file")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var dataDir string
+
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Installs dependencies and sets ccloudvm up for use",
@@ -31,10 +33,11 @@ var setupCmd = &cobra.Command{
 		ctx, cancelFunc := getSignalContext()
 		defer cancelFunc()
 
-		return client.Setup(ctx)
+		return client.Setup(ctx, dataDir)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(setupCmd)
+	setupCmd.Flags().StringVarP(&dataDir, "datadir", "d", "", "The directory where ccloudvm will store cache and instance data. ~/.ccloudvm is used if not specified")
 }


### PR DESCRIPTION
This allows the user to specify the directory that ccloudvm will use to store all of its data.  By default, ccloudvm uses $HOME/.ccloudvm.