### PR TITLE
Use datadir directly rather than datadir/.ccloudvm

### DIFF
--- a/ccvm/prepare.go
+++ b/ccvm/prepare.go
@@ -162,7 +162,7 @@ func prepareEnv(ctx context.Context, name string) (*workspace, error) {
 	ws.GID = os.Getgid()
 
 	if dataDir != "" {
-		ws.ccvmDir = path.Join(dataDir, ".ccloudvm")
+		ws.ccvmDir = dataDir
 	} else {
 		ws.ccvmDir = path.Join(ws.Home, ".ccloudvm")
 	}

--- a/ccvm/server.go
+++ b/ccvm/server.go
@@ -600,14 +600,15 @@ DONE:
 }
 
 func makeDir() (string, error) {
-	home := os.Getenv("CCLOUDVM_DATA_DIR")
-	if home == "" {
-		home = os.Getenv("HOME")
+	ccvmDir := os.Getenv("CCLOUDVM_DATA_DIR")
+	if ccvmDir == "" {
+		home := os.Getenv("HOME")
 		if home == "" {
 			return "", errors.New("HOME is not defined")
 		}
+		ccvmDir = filepath.Join(home, ".ccloudvm")
 	}
-	ccvmDir := filepath.Join(home, ".ccloudvm")
+
 	err := os.MkdirAll(ccvmDir, 0700)
 	if err != nil {
 		return "", errors.Wrapf(err, "Unable to create %s", ccvmDir)


### PR DESCRIPTION
Fix a small issue with the previous commit.  When the user specifies datadir the instance and cache folders are stored directly in that folder and not the within a .ccloudvm folder.