### PR TITLE
add rudimentary support for MACOS

### DIFF
--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -48,7 +48,7 @@ type ccvmBackend struct{}
 func checkMemAvailable(in *types.VMSpec) error {
 	_, available := deviceinfo.GetMemoryInfo()
 	if available == -1 {
-		return fmt.Errorf("Unable to compute memory statistics of host device")
+		return nil
 	}
 
 	if in.MemMiB > available {

--- a/ccvm/ccvm.go
+++ b/ccvm/ccvm.go
@@ -79,6 +79,10 @@ func prepareCreate(ctx context.Context, args *types.CreateArgs) (*workload, *wor
 		return nil, nil, nil, err
 	}
 
+	if args.BIOS != "" {
+		wkld.spec.BIOS = args.BIOS
+	}
+
 	if args.Kernel != "" {
 		wkld.spec.Kernel = args.Kernel
 	}

--- a/ccvm/ccvm_test.go
+++ b/ccvm/ccvm_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -154,6 +155,10 @@ func createDownloader() (*downloader, error) {
 }
 
 func TestSystem(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		/* We need to skip for now as this test will need a BIOS in a known location */
+		t.Skip()
+	}
 	b := ccvmBackend{}
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
 	defer func() {

--- a/ccvm/server.go
+++ b/ccvm/server.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sort"
 	"sync"
 	"syscall"
@@ -103,7 +104,7 @@ type ccvmService struct {
 	shutdownTimer *time.Timer
 	transactions  map[int]transaction
 	cases         []reflect.SelectCase
-	hostIPs       map[uint32]struct{}
+	hostIPs       map[uint32]map[int]struct{}
 	instances     map[string]chan instanceCmd
 	hostIPMask    uint32
 	instanceChMap map[chan struct{}]string
@@ -202,12 +203,16 @@ func flattenIP(ip net.IP) (uint32, error) {
 	return uint32(ip4[0])<<24 | uint32(ip4[1])<<16 | uint32(ip4[2])<<8 | uint32(ip4[3]), nil
 }
 
-func (s *ccvmService) startInstanceLoop(name string, flatIP uint32) chan instanceCmd {
+func (s *ccvmService) startInstanceLoop(name string, flatIP uint32, sshPort int) chan instanceCmd {
 	instanceCh := make(chan instanceCmd)
 	closeCh := make(chan struct{})
 	s.instances[name] = instanceCh
 	s.instanceChMap[closeCh] = name
-	s.hostIPs[flatIP] = struct{}{}
+	_, ok := s.hostIPs[flatIP]
+	if !ok {
+		s.hostIPs[flatIP] = make(map[int]struct{})
+	}
+	s.hostIPs[flatIP][sshPort] = struct{}{}
 	s.instanceWg.Add(1)
 	go instanceLoop(name, instanceCh, closeCh, &s.instanceWg)
 	s.cases = append(s.cases, reflect.SelectCase{
@@ -262,14 +267,16 @@ func (s *ccvmService) findExistingInstances() {
 			return filepath.SkipDir
 		}
 
-		if _, ok := s.hostIPs[flatIP]; ok {
-			fmt.Printf("Host IP address already in use %s\n", details.VMSpec.HostIP)
-			return filepath.SkipDir
+		if ports, ok := s.hostIPs[flatIP]; ok {
+			if _, ok = ports[details.SSH.Port]; ok {
+				fmt.Printf("Host IP %s address and port %d already in use \n", details.VMSpec.HostIP, details.SSH.Port)
+				return filepath.SkipDir
+			}
 		}
 
-		fmt.Printf("Starting instance %s on %s\n", info.Name(), details.VMSpec.HostIP)
+		fmt.Printf("Starting instance %s on %s SSH port %d\n", info.Name(), details.VMSpec.HostIP, details.SSH.Port)
 
-		_ = s.startInstanceLoop(info.Name(), flatIP)
+		_ = s.startInstanceLoop(info.Name(), flatIP, details.SSH.Port)
 
 		return filepath.SkipDir
 	})
@@ -336,31 +343,66 @@ func (s *ccvmService) create(ctx context.Context, resultCh chan interface{}, arg
 	}
 
 	var flatIP uint32
+	var err error
 	if len(args.CustomSpec.HostIP) == 0 {
-		hostIP, i, err := s.findFreeIP()
-		if err != nil {
-			resultCh <- err
-			close(resultCh)
-			return
+		if runtime.GOOS != "darwin" {
+			hostIP, i, err := s.findFreeIP()
+			if err != nil {
+				resultCh <- err
+				close(resultCh)
+				return
+			}
+			args.CustomSpec.HostIP = hostIP
+			flatIP = i
+		} else {
+			args.CustomSpec.HostIP = net.ParseIP("127.0.0.1")
+			flatIP, err = flattenIP(args.CustomSpec.HostIP)
+			if err != nil {
+				resultCh <- err
+				close(resultCh)
+				return
+			}
 		}
-		args.CustomSpec.HostIP = hostIP
-		flatIP = i
 	} else {
-		flatIP, err := flattenIP(args.CustomSpec.HostIP)
+		flatIP, err = flattenIP(args.CustomSpec.HostIP)
 		if err != nil {
 			resultCh <- err
-			close(resultCh)
-			return
-		}
-		_, ok := s.hostIPs[flatIP]
-		if ok {
-			resultCh <- errors.Errorf("IP address %s is already in use", args.CustomSpec.HostIP)
 			close(resultCh)
 			return
 		}
 	}
 
-	instanceCh := s.startInstanceLoop(args.Name, flatIP)
+	ports, ok := s.hostIPs[flatIP]
+	var hostPort int
+	if ok {
+		for _, pm := range args.CustomSpec.PortMappings {
+			if pm.Guest == 22 {
+				hostPort = pm.Host
+			}
+			if _, ok := ports[pm.Host]; ok {
+				resultCh <- errors.Errorf("IP address %s and port %d is already in use", args.CustomSpec.HostIP, pm.Host)
+				close(resultCh)
+				return
+			}
+		}
+
+		if hostPort == 0 {
+			for hostPort = 10022; hostPort < 10100; hostPort++ {
+				if _, ok := ports[hostPort]; !ok {
+					break
+				}
+			}
+
+			if hostPort == 10100 {
+				resultCh <- errors.Errorf("No host ports available for hostIP %s", args.CustomSpec.HostIP)
+				close(resultCh)
+				return
+			}
+			args.CustomSpec.PortMappings = append(args.CustomSpec.PortMappings, types.PortMapping{Guest: 22, Host: hostPort})
+		}
+	}
+
+	instanceCh := s.startInstanceLoop(args.Name, flatIP, hostPort)
 	instanceCh <- instanceCmd{
 		cmdType:  instanceCmdCreate,
 		resultCh: resultCh,
@@ -696,7 +738,7 @@ func startServer(signalCh chan os.Signal) error {
 			downloadCh:    downloadCh,
 			instances:     make(map[string]chan instanceCmd),
 			instanceChMap: make(map[chan struct{}]string),
-			hostIPs:       make(map[uint32]struct{}),
+			hostIPs:       make(map[uint32]map[int]struct{}),
 			hostIPMask:    0x7f000000 | uint32((os.Getuid()&0xffff)<<8),
 			b:             ccvmBackend{},
 		}

--- a/ccvm/server_test.go
+++ b/ccvm/server_test.go
@@ -123,7 +123,7 @@ func setupServer(t *testing.T, b backend, wg *sync.WaitGroup) (string, chan inte
 			downloadCh:    downloadCh,
 			instances:     make(map[string]chan instanceCmd),
 			instanceChMap: make(map[chan struct{}]string),
-			hostIPs:       make(map[uint32]struct{}),
+			hostIPs:       make(map[uint32]map[int]struct{}),
 			hostIPMask:    0x7f000000 | uint32((os.Getuid()&0xffff)<<8),
 			b:             b,
 		}
@@ -159,7 +159,7 @@ func setupServerWithInstances(t *testing.T, b backend, wg *sync.WaitGroup, insta
 			downloadCh:    downloadCh,
 			instances:     make(map[string]chan instanceCmd),
 			instanceChMap: make(map[chan struct{}]string),
-			hostIPs:       make(map[uint32]struct{}),
+			hostIPs:       make(map[uint32]map[int]struct{}),
 			hostIPMask:    0x7f000000 | uint32((os.Getuid()&0xffff)<<8),
 			b:             b,
 		}

--- a/ccvm/vm.go
+++ b/ccvm/vm.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -93,12 +94,23 @@ func bootVM(ctx context.Context, ws *workspace, name string, in *types.VMSpec, c
 	} else {
 		args = append(args, "-machine", machine)
 
-		if cpu != "" {
-			args = append(args, "-cpu", cpu)
-		}
+		if qemuPath == "qemu-system-aarch64" {
+			if runtime.GOOS == "darwin" {
+				args = append(args, "-accel", "hvf")
+			}
+			if cpu == "" {
+				args = append(args, "-cpu", "host")
+			} else {
+				args = append(args, "-cpu", cpu)
+			}
+		} else {
+			if cpu != "" {
+				args = append(args, "-cpu", cpu)
+			}
 
-		if qemuPath == "" {
-			return fmt.Errorf("qemu_path must be specified --machine is set")
+			if qemuPath == "" {
+				return fmt.Errorf("qemu_path must be specified --machine is set")
+			}
 		}
 
 		qemuExe = qemuPath

--- a/ccvm/workload.go
+++ b/ccvm/workload.go
@@ -33,6 +33,8 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"strings"
 	"text/template"
 	"time"
 
@@ -242,6 +244,10 @@ func (wkld *workload) merge(parent *workload) {
 		wkld.spec.InitRD = parent.spec.InitRD
 	}
 
+	if wkld.spec.BIOS == "" {
+		wkld.spec.BIOS = parent.spec.BIOS
+	}
+
 	wkld.spec.VM.Merge(&parent.spec.VM)
 }
 
@@ -316,7 +322,31 @@ func (wkld *workload) parse(ws *workspace) (cloudConfig, error) {
 	}
 
 	var udBuf bytes.Buffer
-	err = udt.Execute(&udBuf, ws)
+	if runtime.GOOS == "darwin" {
+		// hack for macos to map /Users/homedir to /home/homedir
+
+		oldMounts := make([]string, len(ws.Mounts))
+		oldHome := ws.Home
+		for i := range ws.Mounts {
+			oldMounts[i] = ws.Mounts[i].Path
+			if strings.HasPrefix(ws.Mounts[i].Path, "/Users/") {
+				ws.Mounts[i].Path = "/home" + ws.Mounts[i].Path[len("/Users"):]
+			}
+		}
+		if strings.HasPrefix(ws.Home, "/Users/") {
+			ws.Home = "/home" + ws.Home[len("/Users"):]
+		}
+
+		err = udt.Execute(&udBuf, ws)
+
+		ws.Home = oldHome
+		for i := range ws.Mounts {
+			ws.Mounts[i].Path = oldMounts[i]
+		}
+	} else {
+		err = udt.Execute(&udBuf, ws)
+	}
+
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to execute user data template")
 	}

--- a/ccvm/workloads/noble-ARM64.yaml
+++ b/ccvm/workloads/noble-ARM64.yaml
@@ -1,0 +1,60 @@
+---
+base_image_url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img
+base_image_name: Ubuntu 24.04
+qemu: qemu-system-aarch64
+machine: virt
+vm:
+  disk_gib: 16
+...
+---
+{{- define "ENV" -}}
+{{proxyVars .}}
+{{- print " DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true " -}}
+{{end}}
+#cloud-config
+write_files:
+{{with proxyEnv . 5}}
+ - content: |
+{{.}}
+   path: /etc/environment
+{{end}}
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+package_upgrade: {{with .PackageUpgrade}}{{.}}{{else}}false{{end}}
+
+runcmd:
+ - {{beginTask . "Booting VM"}}
+ - {{endTaskOk . }}
+
+ - {{beginTask . (printf "Adding %s to /etc/hosts" .Hostname) }}
+ - echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts
+ - {{endTaskCheck .}}
+
+{{range .Mounts}}
+ - mkdir -p {{.Path}}
+ - sudo chown {{$.User}}:{{$.User}} {{.Tag}}
+ - echo "{{.Tag}} {{.Path}} 9p x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L 0 0" >> /etc/fstab
+{{end}}
+{{range .Mounts}}
+ - {{beginTask $ (printf "Mounting %s" .Path) }}
+ - mount {{.Path}}
+ - {{endTaskCheck $}}
+{{end}}
+
+users:
+  - name: {{.User}}
+    uid: "{{.UID}}"
+    gid: "{{.GID}}"
+    gecos: CIAO Demo User
+    lock-passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - {{.PublicKey}}
+...

--- a/client/client.go
+++ b/client/client.go
@@ -293,7 +293,7 @@ func getProxy(upper, lower string) (string, error) {
 }
 
 // Create sets up the VM
-func Create(ctx context.Context, instanceName, workloadName string, debug bool, update bool, customSpec *types.VMSpec, kernel, kernelArgs, qemuPath, cpu string) error {
+func Create(ctx context.Context, instanceName, workloadName string, debug bool, update bool, customSpec *types.VMSpec, bios, kernel, kernelArgs, qemuPath, cpu string) error {
 	HTTPProxy, err := getProxy("HTTP_PROXY", "http_proxy")
 	if err != nil {
 		return err
@@ -334,6 +334,7 @@ func Create(ctx context.Context, instanceName, workloadName string, debug bool, 
 					HTTPSProxy:   HTTPSProxy,
 					NoProxy:      noProxy,
 					GoPath:       goPath,
+					BIOS:         bios,
 					Kernel:       kernel,
 					KernelArgs:   kernelArgs,
 					QEMUPath:     qemuPath,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -57,6 +57,7 @@ var createMOptsSpec multiOptions
 var createDebug bool
 var createPackageUpgrade bool
 var createHostIP ipAddr
+var bios string
 var kernel string
 var kernelArgs string
 var qemuPath string
@@ -72,7 +73,7 @@ var createCmd = &cobra.Command{
 
 		mergeVMOptions(&createSpec, &createMOptsSpec)
 		createSpec.HostIP = net.IP(createHostIP)
-		return client.Create(ctx, instanceName, args[0], createDebug, createPackageUpgrade, &createSpec, kernel, kernelArgs, qemuPath, cpu)
+		return client.Create(ctx, instanceName, args[0], createDebug, createPackageUpgrade, &createSpec, bios, kernel, kernelArgs, qemuPath, cpu)
 	},
 }
 
@@ -88,6 +89,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createDebug, "debug", false, "Enable debugging mode")
 	createCmd.Flags().BoolVar(&createPackageUpgrade, "package-upgrade", false, "Hint as to whether to upgrade packages on creation")
 	createCmd.Flags().Var(&createHostIP, "hostip", "Host IP address on which instance services will be exposed")
+	createCmd.Flags().StringVar(&bios, "bios", "", "URI of the BIOS to use")
 	createCmd.Flags().StringVar(&kernel, "kernel", "", "URI of kernel to use")
 	createCmd.Flags().StringVar(&kernelArgs, "kernelargs", "", "Arguments to pass to kernel")
 	createCmd.Flags().StringVar(&qemuPath, "qemupath", "", "Full path to QEMU binary")

--- a/types/api.go
+++ b/types/api.go
@@ -30,6 +30,7 @@ type CreateArgs struct {
 	HTTPSProxy   string
 	NoProxy      string
 	GoPath       string
+	BIOS         string
 	Kernel       string
 	KernelArgs   string
 	QEMUPath     string


### PR DESCRIPTION
The user needs to find an appropriate BIOS of ARM and pass it to the create command via the --bios flag when creating instances.